### PR TITLE
Implement storage options and S3 tags

### DIFF
--- a/src/Contracts/Resource.php
+++ b/src/Contracts/Resource.php
@@ -163,6 +163,11 @@ interface Resource
     public function title(string $value): self;
 
     /**
+     * Set the storage options passed to `Storage`.
+     */
+    public function storageOptions(array $values): self;
+
+    /**
      * Add an `when` callback resolver that executes if the condition is
      * `true`.
      *

--- a/src/Resources/File.php
+++ b/src/Resources/File.php
@@ -50,7 +50,7 @@ class File extends Resource
     public function store(Media $model): bool
     {
         return Storage::disk($model->disk)->writeStream(
-            $model->relative_path, $this->stream->resource()
+            $model->relative_path, $this->stream->resource(), $this->getStorageOptionsArray()
         );
     }
 

--- a/src/Resources/Image.php
+++ b/src/Resources/Image.php
@@ -170,7 +170,7 @@ class Image extends Resource
         ));
 
         return Storage::disk($model->disk)->writeStream(
-            $model->relative_path, $stream->resource()
+            $model->relative_path, $stream->resource(), $this->getStorageOptionsArray()
         );
     }
 

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -111,6 +111,25 @@ abstract class Resource implements ResourceInterface, Arrayable
     public ?string $title = null;
 
     /**
+     * The storage options.
+     * 
+     * An array of options to be passed to Laravel's `Storage` facade.
+     * 
+     * For example, when using Amazon S3, a `Tagging` option may be used to set S3 tags:
+     * 
+     * ```php
+     * Resouce::make(...)
+     *   ->storageOptions([
+     *     'Tagging' => 'category=image'
+     *   ])
+     *   ->save();
+     * ```
+     * 
+     * Note that these options will not be persisted to the database.
+     */
+    public ?Collection $storageOptions = null;
+
+    /**
      * Create a new resource instance.
      *
      * @param mixed $data
@@ -390,6 +409,32 @@ abstract class Resource implements ResourceInterface, Arrayable
     }
 
     /**
+     * Set the storage options passed to `Storage`.
+     */
+    public function storageOptions(array $values): self
+    {
+        if(!$this->storageOptions) {
+            $this->storageOptions = collect();
+        }
+
+        $this->storageOptions = $this->storageOptions->merge($values);
+
+        return $this;
+    }
+
+    /**
+     * Gets an array of storage options.
+     * 
+     * Converts `$this->storageOptions` to an array if it exists, or returns an empty array otherwise.
+     * 
+     * @return array
+     */
+    public function getStorageOptionsArray(): array
+    {
+        return $this->storageOptions ? $this->storageOptions->toArray() : [];
+    }
+
+    /**
      * Save the resource and return a model.
      *
      * @return Media|boolean
@@ -442,6 +487,10 @@ abstract class Resource implements ResourceInterface, Arrayable
             (new Collection($values))->flatten(1)
         );
 
+        if ($this->tags->isNotEmpty()) {
+            $this->storageOptions([ 'Tagging' => $this->getS3TagString($this->tags) ]);
+        }
+
         return $this;
     }
 
@@ -487,6 +536,30 @@ abstract class Resource implements ResourceInterface, Arrayable
                 return [$property->getName() => $value];
             })
             ->all();
+    }
+
+    /**
+     * Converts a list of tags to an S3 tag string.
+     * 
+     * Converts the given `Collection` of single "tags" into an S3-compatible key-value query string where each tag is
+     * set to `'true'`.
+     * 
+     * For example:
+     * 
+     * ```php
+     * $tags = collect(['one', 'two', 'three']);
+     * $this->getS3TagString($tags); // => "one=true&two=true&three=true"
+     * ```
+     * 
+     * @param Collection $tags
+     * @return string
+     */
+    protected function getS3TagString(Collection $tags): string
+    {
+        $associativeTags = $tags->mapWithKeys(fn ($tag) => [$tag => 'true']);
+        $queryString = http_build_query($associativeTags->toArray());
+
+        return $queryString;
     }
 
 

--- a/tests/Unit/Resources/FileTest.php
+++ b/tests/Unit/Resources/FileTest.php
@@ -6,9 +6,13 @@ use Actengage\Media\Data\Stream;
 use Actengage\Media\Facades\Resource;
 use Actengage\Media\Media;
 use Actengage\Media\Resources\File;
+use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
+use Tests\Unit\Support\DummyFilesystem;
+use Tests\Unit\Support\DummyFilesystemManager;
 
 class FileTest extends TestCase
 {
@@ -41,5 +45,32 @@ class FileTest extends TestCase
 
         $this->assertTrue($model->delete());
         Storage::disk('public')->assertExists('files/file.txt');
+    }
+
+    public function testSavePassesStorageOptions()
+    {
+        $fs = new DummyFilesystem;
+        Storage::shouldReceive('disk')->andReturn($fs);
+        
+        $file = new UploadedFile(
+            __DIR__.'/../../src/file.txt', 'file.txt'
+        );
+
+        Resource::make($file)
+            ->disk('public')
+            ->directory('files')
+            ->storageOptions([
+                'example' => true,
+                'config' => 'one'
+            ])
+            ->save();
+        
+        $this->assertEquals(
+            [
+                'example' => true,
+                'config' => 'one'
+            ],
+            $fs->options
+        );
     }
 }

--- a/tests/Unit/Resources/ImageTest.php
+++ b/tests/Unit/Resources/ImageTest.php
@@ -10,6 +10,7 @@ use Actengage\Media\Support\ExifData;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
+use Tests\Unit\Support\DummyFilesystem;
 
 class ImageTest extends TestCase
 {
@@ -46,5 +47,32 @@ class ImageTest extends TestCase
 
         $this->assertTrue($model->delete());
         Storage::disk('public')->assertExists('images/image.jpeg');
+    }
+
+    public function testSavePassesStorageOptions()
+    {
+        $fs = new DummyFilesystem;
+        Storage::shouldReceive('disk')->andReturn($fs);
+        
+        $file = new UploadedFile(
+            __DIR__.'/../../src/image.jpeg', 'image.jpeg'
+        );
+
+        Resource::make($file)
+            ->disk('public')
+            ->directory('images')
+            ->storageOptions([
+                'example' => true,
+                'config' => 'two'
+            ])
+            ->save();
+        
+        $this->assertEquals(
+            [
+                'example' => true,
+                'config' => 'two'
+            ],
+            $fs->options
+        );
     }
 }

--- a/tests/Unit/Resources/ResourceTest.php
+++ b/tests/Unit/Resources/ResourceTest.php
@@ -200,4 +200,15 @@ class ResourceTest extends TestCase
         $this->assertTrue($resource->save()->exists);
     }
 
+    public function testTagsCorrectlySetsTaggingStorageOption()
+    {
+        $resource = Resource::path(__DIR__.'/../../src/file.txt')
+            ->tags(['a', 'b', 'c']);
+        
+        $this->assertEquals(
+            'a=true&b=true&c=true',
+            $resource->storageOptions->get('Tagging')
+        );
+    }
+
 }

--- a/tests/Unit/Support/DummyFilesystem.php
+++ b/tests/Unit/Support/DummyFilesystem.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use League\Flysystem\Local\LocalFilesystemAdapter;
+
+class DummyFilesystem
+{
+    public ?array $options;
+
+    public function writeStream($path, $resource, array $options = [])
+    {
+        $this->options = $options;
+
+        return true;
+    }
+}


### PR DESCRIPTION
Write and test functionality to allow setting the "storage options" that are passed to the `Storage` facade.

Also automatically set a `Tagging` option when tags are set on resources. This will set S3 tags on an S3 filesystem.